### PR TITLE
Allow creating vectors generically from index-mapping functions.

### DIFF
--- a/src-128/Data/Primitive/SIMD/Class.hs
+++ b/src-128/Data/Primitive/SIMD/Class.hs
@@ -35,6 +35,9 @@ class (Num v, Real (Elem v)) => SIMDVector v where
     elementSize      :: v -> Int
     -- | Broadcast a scalar to all elements of a vector.
     broadcastVector  :: Elem v -> v
+    -- | The vector that results from applying the given function to all indices in
+    --   the range @0 .. 'vectorSize' - 1@.
+    generateVector   :: (Int -> Elem v) -> v
     -- | Insert a scalar at the given position (starting from 0) in a vector. If the index is outside of the range an exception is thrown.
     insertVector     :: v -> Elem v -> Int -> v
     insertVector v e i | i < 0            = error $ "insertVector: negative argument: " ++ show i

--- a/src-128/Data/Primitive/SIMD/DoubleX16.hs
+++ b/src-128/Data/Primitive/SIMD/DoubleX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX16 where
     vectorSize  _      = 16
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX16
+    generateVector     = generateDoubleX16
     unsafeInsertVector = unsafeInsertDoubleX16
     packVector         = packDoubleX16
     unpackVector       = unpackDoubleX16
@@ -176,6 +177,11 @@ instance Unbox DoubleX16
 broadcastDoubleX16 :: Double -> DoubleX16
 broadcastDoubleX16 (D# x) = case broadcastDoubleX2# x of
     v -> DoubleX16 v v v v v v v v
+
+{-# INLINE[1] generateDoubleX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX16 :: (Int -> Double) -> DoubleX16
+generateDoubleX16 f = packDoubleX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packDoubleX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/DoubleX2.hs
+++ b/src-128/Data/Primitive/SIMD/DoubleX2.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX2
+    generateVector     = generateDoubleX2
     unsafeInsertVector = unsafeInsertDoubleX2
     packVector         = packDoubleX2
     unpackVector       = unpackDoubleX2
@@ -174,6 +175,11 @@ instance Unbox DoubleX2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX2 :: Double -> DoubleX2
 broadcastDoubleX2 (D# x) = DoubleX2 (broadcastDoubleX2# x)
+
+{-# INLINE[1] generateDoubleX2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX2 :: (Int -> Double) -> DoubleX2
+generateDoubleX2 f = packDoubleX2 (f 0, f 1)
 
 {-# INLINE packDoubleX2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/DoubleX4.hs
+++ b/src-128/Data/Primitive/SIMD/DoubleX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX4
+    generateVector     = generateDoubleX4
     unsafeInsertVector = unsafeInsertDoubleX4
     packVector         = packDoubleX4
     unpackVector       = unpackDoubleX4
@@ -176,6 +177,11 @@ instance Unbox DoubleX4
 broadcastDoubleX4 :: Double -> DoubleX4
 broadcastDoubleX4 (D# x) = case broadcastDoubleX2# x of
     v -> DoubleX4 v v
+
+{-# INLINE[1] generateDoubleX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX4 :: (Int -> Double) -> DoubleX4
+generateDoubleX4 f = packDoubleX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packDoubleX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/DoubleX8.hs
+++ b/src-128/Data/Primitive/SIMD/DoubleX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX8
+    generateVector     = generateDoubleX8
     unsafeInsertVector = unsafeInsertDoubleX8
     packVector         = packDoubleX8
     unpackVector       = unpackDoubleX8
@@ -176,6 +177,11 @@ instance Unbox DoubleX8
 broadcastDoubleX8 :: Double -> DoubleX8
 broadcastDoubleX8 (D# x) = case broadcastDoubleX2# x of
     v -> DoubleX8 v v v v
+
+{-# INLINE[1] generateDoubleX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX8 :: (Int -> Double) -> DoubleX8
+generateDoubleX8 f = packDoubleX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packDoubleX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/FloatX16.hs
+++ b/src-128/Data/Primitive/SIMD/FloatX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastFloatX16
+    generateVector     = generateFloatX16
     unsafeInsertVector = unsafeInsertFloatX16
     packVector         = packFloatX16
     unpackVector       = unpackFloatX16
@@ -176,6 +177,11 @@ instance Unbox FloatX16
 broadcastFloatX16 :: Float -> FloatX16
 broadcastFloatX16 (F# x) = case broadcastFloatX4# x of
     v -> FloatX16 v v v v
+
+{-# INLINE[1] generateFloatX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX16 :: (Int -> Float) -> FloatX16
+generateFloatX16 f = packFloatX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packFloatX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/FloatX4.hs
+++ b/src-128/Data/Primitive/SIMD/FloatX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastFloatX4
+    generateVector     = generateFloatX4
     unsafeInsertVector = unsafeInsertFloatX4
     packVector         = packFloatX4
     unpackVector       = unpackFloatX4
@@ -174,6 +175,11 @@ instance Unbox FloatX4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX4 :: Float -> FloatX4
 broadcastFloatX4 (F# x) = FloatX4 (broadcastFloatX4# x)
+
+{-# INLINE[1] generateFloatX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX4 :: (Int -> Float) -> FloatX4
+generateFloatX4 f = packFloatX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packFloatX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/FloatX8.hs
+++ b/src-128/Data/Primitive/SIMD/FloatX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastFloatX8
+    generateVector     = generateFloatX8
     unsafeInsertVector = unsafeInsertFloatX8
     packVector         = packFloatX8
     unpackVector       = unpackFloatX8
@@ -176,6 +177,11 @@ instance Unbox FloatX8
 broadcastFloatX8 :: Float -> FloatX8
 broadcastFloatX8 (F# x) = case broadcastFloatX4# x of
     v -> FloatX8 v v
+
+{-# INLINE[1] generateFloatX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX8 :: (Int -> Float) -> FloatX8
+generateFloatX8 f = packFloatX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packFloatX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int16X16.hs
+++ b/src-128/Data/Primitive/SIMD/Int16X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastInt16X16
+    generateVector     = generateInt16X16
     unsafeInsertVector = unsafeInsertInt16X16
     packVector         = packInt16X16
     unpackVector       = unpackInt16X16
@@ -161,6 +162,11 @@ instance Unbox Int16X16
 broadcastInt16X16 :: Int16 -> Int16X16
 broadcastInt16X16 (I16# x) = case broadcastInt16X8# x of
     v -> Int16X16 v v
+
+{-# INLINE[1] generateInt16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X16 :: (Int -> Int16) -> Int16X16
+generateInt16X16 f = packInt16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int16X32.hs
+++ b/src-128/Data/Primitive/SIMD/Int16X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastInt16X32
+    generateVector     = generateInt16X32
     unsafeInsertVector = unsafeInsertInt16X32
     packVector         = packInt16X32
     unpackVector       = unpackInt16X32
@@ -161,6 +162,11 @@ instance Unbox Int16X32
 broadcastInt16X32 :: Int16 -> Int16X32
 broadcastInt16X32 (I16# x) = case broadcastInt16X8# x of
     v -> Int16X32 v v v v
+
+{-# INLINE[1] generateInt16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X32 :: (Int -> Int16) -> Int16X32
+generateInt16X32 f = packInt16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int16X8.hs
+++ b/src-128/Data/Primitive/SIMD/Int16X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastInt16X8
+    generateVector     = generateInt16X8
     unsafeInsertVector = unsafeInsertInt16X8
     packVector         = packInt16X8
     unpackVector       = unpackInt16X8
@@ -159,6 +160,11 @@ instance Unbox Int16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X8 :: Int16 -> Int16X8
 broadcastInt16X8 (I16# x) = Int16X8 (broadcastInt16X8# x)
+
+{-# INLINE[1] generateInt16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X8 :: (Int -> Int16) -> Int16X8
+generateInt16X8 f = packInt16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int32X16.hs
+++ b/src-128/Data/Primitive/SIMD/Int32X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastInt32X16
+    generateVector     = generateInt32X16
     unsafeInsertVector = unsafeInsertInt32X16
     packVector         = packInt32X16
     unpackVector       = unpackInt32X16
@@ -161,6 +162,11 @@ instance Unbox Int32X16
 broadcastInt32X16 :: Int32 -> Int32X16
 broadcastInt32X16 (I32# x) = case broadcastInt32X4# x of
     v -> Int32X16 v v v v
+
+{-# INLINE[1] generateInt32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X16 :: (Int -> Int32) -> Int32X16
+generateInt32X16 f = packInt32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int32X4.hs
+++ b/src-128/Data/Primitive/SIMD/Int32X4.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastInt32X4
+    generateVector     = generateInt32X4
     unsafeInsertVector = unsafeInsertInt32X4
     packVector         = packInt32X4
     unpackVector       = unpackInt32X4
@@ -159,6 +160,11 @@ instance Unbox Int32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X4 :: Int32 -> Int32X4
 broadcastInt32X4 (I32# x) = Int32X4 (broadcastInt32X4# x)
+
+{-# INLINE[1] generateInt32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X4 :: (Int -> Int32) -> Int32X4
+generateInt32X4 f = packInt32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int32X8.hs
+++ b/src-128/Data/Primitive/SIMD/Int32X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastInt32X8
+    generateVector     = generateInt32X8
     unsafeInsertVector = unsafeInsertInt32X8
     packVector         = packInt32X8
     unpackVector       = unpackInt32X8
@@ -161,6 +162,11 @@ instance Unbox Int32X8
 broadcastInt32X8 :: Int32 -> Int32X8
 broadcastInt32X8 (I32# x) = case broadcastInt32X4# x of
     v -> Int32X8 v v
+
+{-# INLINE[1] generateInt32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X8 :: (Int -> Int32) -> Int32X8
+generateInt32X8 f = packInt32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int64X2.hs
+++ b/src-128/Data/Primitive/SIMD/Int64X2.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastInt64X2
+    generateVector     = generateInt64X2
     unsafeInsertVector = unsafeInsertInt64X2
     packVector         = packInt64X2
     unpackVector       = unpackInt64X2
@@ -169,6 +170,11 @@ instance Unbox Int64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X2 :: Int64 -> Int64X2
 broadcastInt64X2 (I64# x) = Int64X2 (broadcastInt64X2# x)
+
+{-# INLINE[1] generateInt64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X2 :: (Int -> Int64) -> Int64X2
+generateInt64X2 f = packInt64X2 (f 0, f 1)
 
 {-# INLINE packInt64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int64X4.hs
+++ b/src-128/Data/Primitive/SIMD/Int64X4.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastInt64X4
+    generateVector     = generateInt64X4
     unsafeInsertVector = unsafeInsertInt64X4
     packVector         = packInt64X4
     unpackVector       = unpackInt64X4
@@ -171,6 +172,11 @@ instance Unbox Int64X4
 broadcastInt64X4 :: Int64 -> Int64X4
 broadcastInt64X4 (I64# x) = case broadcastInt64X2# x of
     v -> Int64X4 v v
+
+{-# INLINE[1] generateInt64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X4 :: (Int -> Int64) -> Int64X4
+generateInt64X4 f = packInt64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int64X8.hs
+++ b/src-128/Data/Primitive/SIMD/Int64X8.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastInt64X8
+    generateVector     = generateInt64X8
     unsafeInsertVector = unsafeInsertInt64X8
     packVector         = packInt64X8
     unpackVector       = unpackInt64X8
@@ -171,6 +172,11 @@ instance Unbox Int64X8
 broadcastInt64X8 :: Int64 -> Int64X8
 broadcastInt64X8 (I64# x) = case broadcastInt64X2# x of
     v -> Int64X8 v v v v
+
+{-# INLINE[1] generateInt64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X8 :: (Int -> Int64) -> Int64X8
+generateInt64X8 f = packInt64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int8X16.hs
+++ b/src-128/Data/Primitive/SIMD/Int8X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastInt8X16
+    generateVector     = generateInt8X16
     unsafeInsertVector = unsafeInsertInt8X16
     packVector         = packInt8X16
     unpackVector       = unpackInt8X16
@@ -159,6 +160,11 @@ instance Unbox Int8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt8X16 :: Int8 -> Int8X16
 broadcastInt8X16 (I8# x) = Int8X16 (broadcastInt8X16# x)
+
+{-# INLINE[1] generateInt8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X16 :: (Int -> Int8) -> Int8X16
+generateInt8X16 f = packInt8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int8X32.hs
+++ b/src-128/Data/Primitive/SIMD/Int8X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastInt8X32
+    generateVector     = generateInt8X32
     unsafeInsertVector = unsafeInsertInt8X32
     packVector         = packInt8X32
     unpackVector       = unpackInt8X32
@@ -161,6 +162,11 @@ instance Unbox Int8X32
 broadcastInt8X32 :: Int8 -> Int8X32
 broadcastInt8X32 (I8# x) = case broadcastInt8X16# x of
     v -> Int8X32 v v
+
+{-# INLINE[1] generateInt8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X32 :: (Int -> Int8) -> Int8X32
+generateInt8X32 f = packInt8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Int8X64.hs
+++ b/src-128/Data/Primitive/SIMD/Int8X64.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastInt8X64
+    generateVector     = generateInt8X64
     unsafeInsertVector = unsafeInsertInt8X64
     packVector         = packInt8X64
     unpackVector       = unpackInt8X64
@@ -161,6 +162,11 @@ instance Unbox Int8X64
 broadcastInt8X64 :: Int8 -> Int8X64
 broadcastInt8X64 (I8# x) = case broadcastInt8X16# x of
     v -> Int8X64 v v v v
+
+{-# INLINE[1] generateInt8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X64 :: (Int -> Int8) -> Int8X64
+generateInt8X64 f = packInt8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packInt8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word16X16.hs
+++ b/src-128/Data/Primitive/SIMD/Word16X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastWord16X16
+    generateVector     = generateWord16X16
     unsafeInsertVector = unsafeInsertWord16X16
     packVector         = packWord16X16
     unpackVector       = unpackWord16X16
@@ -160,6 +161,11 @@ instance Unbox Word16X16
 broadcastWord16X16 :: Word16 -> Word16X16
 broadcastWord16X16 (W16# x) = case broadcastWord16X8# x of
     v -> Word16X16 v v
+
+{-# INLINE[1] generateWord16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X16 :: (Int -> Word16) -> Word16X16
+generateWord16X16 f = packWord16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word16X32.hs
+++ b/src-128/Data/Primitive/SIMD/Word16X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastWord16X32
+    generateVector     = generateWord16X32
     unsafeInsertVector = unsafeInsertWord16X32
     packVector         = packWord16X32
     unpackVector       = unpackWord16X32
@@ -160,6 +161,11 @@ instance Unbox Word16X32
 broadcastWord16X32 :: Word16 -> Word16X32
 broadcastWord16X32 (W16# x) = case broadcastWord16X8# x of
     v -> Word16X32 v v v v
+
+{-# INLINE[1] generateWord16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X32 :: (Int -> Word16) -> Word16X32
+generateWord16X32 f = packWord16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word16X8.hs
+++ b/src-128/Data/Primitive/SIMD/Word16X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastWord16X8
+    generateVector     = generateWord16X8
     unsafeInsertVector = unsafeInsertWord16X8
     packVector         = packWord16X8
     unpackVector       = unpackWord16X8
@@ -158,6 +159,11 @@ instance Unbox Word16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X8 :: Word16 -> Word16X8
 broadcastWord16X8 (W16# x) = Word16X8 (broadcastWord16X8# x)
+
+{-# INLINE[1] generateWord16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X8 :: (Int -> Word16) -> Word16X8
+generateWord16X8 f = packWord16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word32X16.hs
+++ b/src-128/Data/Primitive/SIMD/Word32X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastWord32X16
+    generateVector     = generateWord32X16
     unsafeInsertVector = unsafeInsertWord32X16
     packVector         = packWord32X16
     unpackVector       = unpackWord32X16
@@ -160,6 +161,11 @@ instance Unbox Word32X16
 broadcastWord32X16 :: Word32 -> Word32X16
 broadcastWord32X16 (W32# x) = case broadcastWord32X4# x of
     v -> Word32X16 v v v v
+
+{-# INLINE[1] generateWord32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X16 :: (Int -> Word32) -> Word32X16
+generateWord32X16 f = packWord32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word32X4.hs
+++ b/src-128/Data/Primitive/SIMD/Word32X4.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastWord32X4
+    generateVector     = generateWord32X4
     unsafeInsertVector = unsafeInsertWord32X4
     packVector         = packWord32X4
     unpackVector       = unpackWord32X4
@@ -158,6 +159,11 @@ instance Unbox Word32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X4 :: Word32 -> Word32X4
 broadcastWord32X4 (W32# x) = Word32X4 (broadcastWord32X4# x)
+
+{-# INLINE[1] generateWord32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X4 :: (Int -> Word32) -> Word32X4
+generateWord32X4 f = packWord32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word32X8.hs
+++ b/src-128/Data/Primitive/SIMD/Word32X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastWord32X8
+    generateVector     = generateWord32X8
     unsafeInsertVector = unsafeInsertWord32X8
     packVector         = packWord32X8
     unpackVector       = unpackWord32X8
@@ -160,6 +161,11 @@ instance Unbox Word32X8
 broadcastWord32X8 :: Word32 -> Word32X8
 broadcastWord32X8 (W32# x) = case broadcastWord32X4# x of
     v -> Word32X8 v v
+
+{-# INLINE[1] generateWord32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X8 :: (Int -> Word32) -> Word32X8
+generateWord32X8 f = packWord32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word64X2.hs
+++ b/src-128/Data/Primitive/SIMD/Word64X2.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastWord64X2
+    generateVector     = generateWord64X2
     unsafeInsertVector = unsafeInsertWord64X2
     packVector         = packWord64X2
     unpackVector       = unpackWord64X2
@@ -168,6 +169,11 @@ instance Unbox Word64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X2 :: Word64 -> Word64X2
 broadcastWord64X2 (W64# x) = Word64X2 (broadcastWord64X2# x)
+
+{-# INLINE[1] generateWord64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X2 :: (Int -> Word64) -> Word64X2
+generateWord64X2 f = packWord64X2 (f 0, f 1)
 
 {-# INLINE packWord64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word64X4.hs
+++ b/src-128/Data/Primitive/SIMD/Word64X4.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastWord64X4
+    generateVector     = generateWord64X4
     unsafeInsertVector = unsafeInsertWord64X4
     packVector         = packWord64X4
     unpackVector       = unpackWord64X4
@@ -170,6 +171,11 @@ instance Unbox Word64X4
 broadcastWord64X4 :: Word64 -> Word64X4
 broadcastWord64X4 (W64# x) = case broadcastWord64X2# x of
     v -> Word64X4 v v
+
+{-# INLINE[1] generateWord64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X4 :: (Int -> Word64) -> Word64X4
+generateWord64X4 f = packWord64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word64X8.hs
+++ b/src-128/Data/Primitive/SIMD/Word64X8.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastWord64X8
+    generateVector     = generateWord64X8
     unsafeInsertVector = unsafeInsertWord64X8
     packVector         = packWord64X8
     unpackVector       = unpackWord64X8
@@ -170,6 +171,11 @@ instance Unbox Word64X8
 broadcastWord64X8 :: Word64 -> Word64X8
 broadcastWord64X8 (W64# x) = case broadcastWord64X2# x of
     v -> Word64X8 v v v v
+
+{-# INLINE[1] generateWord64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X8 :: (Int -> Word64) -> Word64X8
+generateWord64X8 f = packWord64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word8X16.hs
+++ b/src-128/Data/Primitive/SIMD/Word8X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastWord8X16
+    generateVector     = generateWord8X16
     unsafeInsertVector = unsafeInsertWord8X16
     packVector         = packWord8X16
     unpackVector       = unpackWord8X16
@@ -158,6 +159,11 @@ instance Unbox Word8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord8X16 :: Word8 -> Word8X16
 broadcastWord8X16 (W8# x) = Word8X16 (broadcastWord8X16# x)
+
+{-# INLINE[1] generateWord8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X16 :: (Int -> Word8) -> Word8X16
+generateWord8X16 f = packWord8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word8X32.hs
+++ b/src-128/Data/Primitive/SIMD/Word8X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastWord8X32
+    generateVector     = generateWord8X32
     unsafeInsertVector = unsafeInsertWord8X32
     packVector         = packWord8X32
     unpackVector       = unpackWord8X32
@@ -160,6 +161,11 @@ instance Unbox Word8X32
 broadcastWord8X32 :: Word8 -> Word8X32
 broadcastWord8X32 (W8# x) = case broadcastWord8X16# x of
     v -> Word8X32 v v
+
+{-# INLINE[1] generateWord8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X32 :: (Int -> Word8) -> Word8X32
+generateWord8X32 f = packWord8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-128/Data/Primitive/SIMD/Word8X64.hs
+++ b/src-128/Data/Primitive/SIMD/Word8X64.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastWord8X64
+    generateVector     = generateWord8X64
     unsafeInsertVector = unsafeInsertWord8X64
     packVector         = packWord8X64
     unpackVector       = unpackWord8X64
@@ -160,6 +161,11 @@ instance Unbox Word8X64
 broadcastWord8X64 :: Word8 -> Word8X64
 broadcastWord8X64 (W8# x) = case broadcastWord8X16# x of
     v -> Word8X64 v v v v
+
+{-# INLINE[1] generateWord8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X64 :: (Int -> Word8) -> Word8X64
+generateWord8X64 f = packWord8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packWord8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Class.hs
+++ b/src-256/Data/Primitive/SIMD/Class.hs
@@ -35,6 +35,9 @@ class (Num v, Real (Elem v)) => SIMDVector v where
     elementSize      :: v -> Int
     -- | Broadcast a scalar to all elements of a vector.
     broadcastVector  :: Elem v -> v
+    -- | The vector that results from applying the given function to all indices in
+    --   the range @0 .. 'vectorSize' - 1@.
+    generateVector   :: (Int -> Elem v) -> v
     -- | Insert a scalar at the given position (starting from 0) in a vector. If the index is outside of the range an exception is thrown.
     insertVector     :: v -> Elem v -> Int -> v
     insertVector v e i | i < 0            = error $ "insertVector: negative argument: " ++ show i

--- a/src-256/Data/Primitive/SIMD/DoubleX16.hs
+++ b/src-256/Data/Primitive/SIMD/DoubleX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX16 where
     vectorSize  _      = 16
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX16
+    generateVector     = generateDoubleX16
     unsafeInsertVector = unsafeInsertDoubleX16
     packVector         = packDoubleX16
     unpackVector       = unpackDoubleX16
@@ -176,6 +177,11 @@ instance Unbox DoubleX16
 broadcastDoubleX16 :: Double -> DoubleX16
 broadcastDoubleX16 (D# x) = case broadcastDoubleX4# x of
     v -> DoubleX16 v v v v
+
+{-# INLINE[1] generateDoubleX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX16 :: (Int -> Double) -> DoubleX16
+generateDoubleX16 f = packDoubleX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packDoubleX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/DoubleX2.hs
+++ b/src-256/Data/Primitive/SIMD/DoubleX2.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX2
+    generateVector     = generateDoubleX2
     unsafeInsertVector = unsafeInsertDoubleX2
     packVector         = packDoubleX2
     unpackVector       = unpackDoubleX2
@@ -174,6 +175,11 @@ instance Unbox DoubleX2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX2 :: Double -> DoubleX2
 broadcastDoubleX2 (D# x) = DoubleX2 (broadcastDoubleX2# x)
+
+{-# INLINE[1] generateDoubleX2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX2 :: (Int -> Double) -> DoubleX2
+generateDoubleX2 f = packDoubleX2 (f 0, f 1)
 
 {-# INLINE packDoubleX2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/DoubleX4.hs
+++ b/src-256/Data/Primitive/SIMD/DoubleX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX4
+    generateVector     = generateDoubleX4
     unsafeInsertVector = unsafeInsertDoubleX4
     packVector         = packDoubleX4
     unpackVector       = unpackDoubleX4
@@ -174,6 +175,11 @@ instance Unbox DoubleX4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX4 :: Double -> DoubleX4
 broadcastDoubleX4 (D# x) = DoubleX4 (broadcastDoubleX4# x)
+
+{-# INLINE[1] generateDoubleX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX4 :: (Int -> Double) -> DoubleX4
+generateDoubleX4 f = packDoubleX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packDoubleX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/DoubleX8.hs
+++ b/src-256/Data/Primitive/SIMD/DoubleX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX8
+    generateVector     = generateDoubleX8
     unsafeInsertVector = unsafeInsertDoubleX8
     packVector         = packDoubleX8
     unpackVector       = unpackDoubleX8
@@ -176,6 +177,11 @@ instance Unbox DoubleX8
 broadcastDoubleX8 :: Double -> DoubleX8
 broadcastDoubleX8 (D# x) = case broadcastDoubleX4# x of
     v -> DoubleX8 v v
+
+{-# INLINE[1] generateDoubleX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX8 :: (Int -> Double) -> DoubleX8
+generateDoubleX8 f = packDoubleX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packDoubleX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/FloatX16.hs
+++ b/src-256/Data/Primitive/SIMD/FloatX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastFloatX16
+    generateVector     = generateFloatX16
     unsafeInsertVector = unsafeInsertFloatX16
     packVector         = packFloatX16
     unpackVector       = unpackFloatX16
@@ -176,6 +177,11 @@ instance Unbox FloatX16
 broadcastFloatX16 :: Float -> FloatX16
 broadcastFloatX16 (F# x) = case broadcastFloatX8# x of
     v -> FloatX16 v v
+
+{-# INLINE[1] generateFloatX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX16 :: (Int -> Float) -> FloatX16
+generateFloatX16 f = packFloatX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packFloatX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/FloatX4.hs
+++ b/src-256/Data/Primitive/SIMD/FloatX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastFloatX4
+    generateVector     = generateFloatX4
     unsafeInsertVector = unsafeInsertFloatX4
     packVector         = packFloatX4
     unpackVector       = unpackFloatX4
@@ -174,6 +175,11 @@ instance Unbox FloatX4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX4 :: Float -> FloatX4
 broadcastFloatX4 (F# x) = FloatX4 (broadcastFloatX4# x)
+
+{-# INLINE[1] generateFloatX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX4 :: (Int -> Float) -> FloatX4
+generateFloatX4 f = packFloatX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packFloatX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/FloatX8.hs
+++ b/src-256/Data/Primitive/SIMD/FloatX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastFloatX8
+    generateVector     = generateFloatX8
     unsafeInsertVector = unsafeInsertFloatX8
     packVector         = packFloatX8
     unpackVector       = unpackFloatX8
@@ -174,6 +175,11 @@ instance Unbox FloatX8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX8 :: Float -> FloatX8
 broadcastFloatX8 (F# x) = FloatX8 (broadcastFloatX8# x)
+
+{-# INLINE[1] generateFloatX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX8 :: (Int -> Float) -> FloatX8
+generateFloatX8 f = packFloatX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packFloatX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int16X16.hs
+++ b/src-256/Data/Primitive/SIMD/Int16X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastInt16X16
+    generateVector     = generateInt16X16
     unsafeInsertVector = unsafeInsertInt16X16
     packVector         = packInt16X16
     unpackVector       = unpackInt16X16
@@ -159,6 +160,11 @@ instance Unbox Int16X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X16 :: Int16 -> Int16X16
 broadcastInt16X16 (I16# x) = Int16X16 (broadcastInt16X16# x)
+
+{-# INLINE[1] generateInt16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X16 :: (Int -> Int16) -> Int16X16
+generateInt16X16 f = packInt16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int16X32.hs
+++ b/src-256/Data/Primitive/SIMD/Int16X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastInt16X32
+    generateVector     = generateInt16X32
     unsafeInsertVector = unsafeInsertInt16X32
     packVector         = packInt16X32
     unpackVector       = unpackInt16X32
@@ -161,6 +162,11 @@ instance Unbox Int16X32
 broadcastInt16X32 :: Int16 -> Int16X32
 broadcastInt16X32 (I16# x) = case broadcastInt16X16# x of
     v -> Int16X32 v v
+
+{-# INLINE[1] generateInt16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X32 :: (Int -> Int16) -> Int16X32
+generateInt16X32 f = packInt16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int16X8.hs
+++ b/src-256/Data/Primitive/SIMD/Int16X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastInt16X8
+    generateVector     = generateInt16X8
     unsafeInsertVector = unsafeInsertInt16X8
     packVector         = packInt16X8
     unpackVector       = unpackInt16X8
@@ -159,6 +160,11 @@ instance Unbox Int16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X8 :: Int16 -> Int16X8
 broadcastInt16X8 (I16# x) = Int16X8 (broadcastInt16X8# x)
+
+{-# INLINE[1] generateInt16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X8 :: (Int -> Int16) -> Int16X8
+generateInt16X8 f = packInt16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int32X16.hs
+++ b/src-256/Data/Primitive/SIMD/Int32X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastInt32X16
+    generateVector     = generateInt32X16
     unsafeInsertVector = unsafeInsertInt32X16
     packVector         = packInt32X16
     unpackVector       = unpackInt32X16
@@ -161,6 +162,11 @@ instance Unbox Int32X16
 broadcastInt32X16 :: Int32 -> Int32X16
 broadcastInt32X16 (I32# x) = case broadcastInt32X8# x of
     v -> Int32X16 v v
+
+{-# INLINE[1] generateInt32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X16 :: (Int -> Int32) -> Int32X16
+generateInt32X16 f = packInt32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int32X4.hs
+++ b/src-256/Data/Primitive/SIMD/Int32X4.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastInt32X4
+    generateVector     = generateInt32X4
     unsafeInsertVector = unsafeInsertInt32X4
     packVector         = packInt32X4
     unpackVector       = unpackInt32X4
@@ -159,6 +160,11 @@ instance Unbox Int32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X4 :: Int32 -> Int32X4
 broadcastInt32X4 (I32# x) = Int32X4 (broadcastInt32X4# x)
+
+{-# INLINE[1] generateInt32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X4 :: (Int -> Int32) -> Int32X4
+generateInt32X4 f = packInt32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int32X8.hs
+++ b/src-256/Data/Primitive/SIMD/Int32X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastInt32X8
+    generateVector     = generateInt32X8
     unsafeInsertVector = unsafeInsertInt32X8
     packVector         = packInt32X8
     unpackVector       = unpackInt32X8
@@ -159,6 +160,11 @@ instance Unbox Int32X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X8 :: Int32 -> Int32X8
 broadcastInt32X8 (I32# x) = Int32X8 (broadcastInt32X8# x)
+
+{-# INLINE[1] generateInt32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X8 :: (Int -> Int32) -> Int32X8
+generateInt32X8 f = packInt32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int64X2.hs
+++ b/src-256/Data/Primitive/SIMD/Int64X2.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastInt64X2
+    generateVector     = generateInt64X2
     unsafeInsertVector = unsafeInsertInt64X2
     packVector         = packInt64X2
     unpackVector       = unpackInt64X2
@@ -169,6 +170,11 @@ instance Unbox Int64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X2 :: Int64 -> Int64X2
 broadcastInt64X2 (I64# x) = Int64X2 (broadcastInt64X2# x)
+
+{-# INLINE[1] generateInt64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X2 :: (Int -> Int64) -> Int64X2
+generateInt64X2 f = packInt64X2 (f 0, f 1)
 
 {-# INLINE packInt64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int64X4.hs
+++ b/src-256/Data/Primitive/SIMD/Int64X4.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastInt64X4
+    generateVector     = generateInt64X4
     unsafeInsertVector = unsafeInsertInt64X4
     packVector         = packInt64X4
     unpackVector       = unpackInt64X4
@@ -169,6 +170,11 @@ instance Unbox Int64X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X4 :: Int64 -> Int64X4
 broadcastInt64X4 (I64# x) = Int64X4 (broadcastInt64X4# x)
+
+{-# INLINE[1] generateInt64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X4 :: (Int -> Int64) -> Int64X4
+generateInt64X4 f = packInt64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int64X8.hs
+++ b/src-256/Data/Primitive/SIMD/Int64X8.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastInt64X8
+    generateVector     = generateInt64X8
     unsafeInsertVector = unsafeInsertInt64X8
     packVector         = packInt64X8
     unpackVector       = unpackInt64X8
@@ -171,6 +172,11 @@ instance Unbox Int64X8
 broadcastInt64X8 :: Int64 -> Int64X8
 broadcastInt64X8 (I64# x) = case broadcastInt64X4# x of
     v -> Int64X8 v v
+
+{-# INLINE[1] generateInt64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X8 :: (Int -> Int64) -> Int64X8
+generateInt64X8 f = packInt64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int8X16.hs
+++ b/src-256/Data/Primitive/SIMD/Int8X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastInt8X16
+    generateVector     = generateInt8X16
     unsafeInsertVector = unsafeInsertInt8X16
     packVector         = packInt8X16
     unpackVector       = unpackInt8X16
@@ -159,6 +160,11 @@ instance Unbox Int8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt8X16 :: Int8 -> Int8X16
 broadcastInt8X16 (I8# x) = Int8X16 (broadcastInt8X16# x)
+
+{-# INLINE[1] generateInt8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X16 :: (Int -> Int8) -> Int8X16
+generateInt8X16 f = packInt8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int8X32.hs
+++ b/src-256/Data/Primitive/SIMD/Int8X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastInt8X32
+    generateVector     = generateInt8X32
     unsafeInsertVector = unsafeInsertInt8X32
     packVector         = packInt8X32
     unpackVector       = unpackInt8X32
@@ -159,6 +160,11 @@ instance Unbox Int8X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt8X32 :: Int8 -> Int8X32
 broadcastInt8X32 (I8# x) = Int8X32 (broadcastInt8X32# x)
+
+{-# INLINE[1] generateInt8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X32 :: (Int -> Int8) -> Int8X32
+generateInt8X32 f = packInt8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Int8X64.hs
+++ b/src-256/Data/Primitive/SIMD/Int8X64.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastInt8X64
+    generateVector     = generateInt8X64
     unsafeInsertVector = unsafeInsertInt8X64
     packVector         = packInt8X64
     unpackVector       = unpackInt8X64
@@ -161,6 +162,11 @@ instance Unbox Int8X64
 broadcastInt8X64 :: Int8 -> Int8X64
 broadcastInt8X64 (I8# x) = case broadcastInt8X32# x of
     v -> Int8X64 v v
+
+{-# INLINE[1] generateInt8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X64 :: (Int -> Int8) -> Int8X64
+generateInt8X64 f = packInt8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packInt8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word16X16.hs
+++ b/src-256/Data/Primitive/SIMD/Word16X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastWord16X16
+    generateVector     = generateWord16X16
     unsafeInsertVector = unsafeInsertWord16X16
     packVector         = packWord16X16
     unpackVector       = unpackWord16X16
@@ -158,6 +159,11 @@ instance Unbox Word16X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X16 :: Word16 -> Word16X16
 broadcastWord16X16 (W16# x) = Word16X16 (broadcastWord16X16# x)
+
+{-# INLINE[1] generateWord16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X16 :: (Int -> Word16) -> Word16X16
+generateWord16X16 f = packWord16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word16X32.hs
+++ b/src-256/Data/Primitive/SIMD/Word16X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastWord16X32
+    generateVector     = generateWord16X32
     unsafeInsertVector = unsafeInsertWord16X32
     packVector         = packWord16X32
     unpackVector       = unpackWord16X32
@@ -160,6 +161,11 @@ instance Unbox Word16X32
 broadcastWord16X32 :: Word16 -> Word16X32
 broadcastWord16X32 (W16# x) = case broadcastWord16X16# x of
     v -> Word16X32 v v
+
+{-# INLINE[1] generateWord16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X32 :: (Int -> Word16) -> Word16X32
+generateWord16X32 f = packWord16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word16X8.hs
+++ b/src-256/Data/Primitive/SIMD/Word16X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastWord16X8
+    generateVector     = generateWord16X8
     unsafeInsertVector = unsafeInsertWord16X8
     packVector         = packWord16X8
     unpackVector       = unpackWord16X8
@@ -158,6 +159,11 @@ instance Unbox Word16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X8 :: Word16 -> Word16X8
 broadcastWord16X8 (W16# x) = Word16X8 (broadcastWord16X8# x)
+
+{-# INLINE[1] generateWord16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X8 :: (Int -> Word16) -> Word16X8
+generateWord16X8 f = packWord16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word32X16.hs
+++ b/src-256/Data/Primitive/SIMD/Word32X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastWord32X16
+    generateVector     = generateWord32X16
     unsafeInsertVector = unsafeInsertWord32X16
     packVector         = packWord32X16
     unpackVector       = unpackWord32X16
@@ -160,6 +161,11 @@ instance Unbox Word32X16
 broadcastWord32X16 :: Word32 -> Word32X16
 broadcastWord32X16 (W32# x) = case broadcastWord32X8# x of
     v -> Word32X16 v v
+
+{-# INLINE[1] generateWord32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X16 :: (Int -> Word32) -> Word32X16
+generateWord32X16 f = packWord32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word32X4.hs
+++ b/src-256/Data/Primitive/SIMD/Word32X4.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastWord32X4
+    generateVector     = generateWord32X4
     unsafeInsertVector = unsafeInsertWord32X4
     packVector         = packWord32X4
     unpackVector       = unpackWord32X4
@@ -158,6 +159,11 @@ instance Unbox Word32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X4 :: Word32 -> Word32X4
 broadcastWord32X4 (W32# x) = Word32X4 (broadcastWord32X4# x)
+
+{-# INLINE[1] generateWord32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X4 :: (Int -> Word32) -> Word32X4
+generateWord32X4 f = packWord32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word32X8.hs
+++ b/src-256/Data/Primitive/SIMD/Word32X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastWord32X8
+    generateVector     = generateWord32X8
     unsafeInsertVector = unsafeInsertWord32X8
     packVector         = packWord32X8
     unpackVector       = unpackWord32X8
@@ -158,6 +159,11 @@ instance Unbox Word32X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X8 :: Word32 -> Word32X8
 broadcastWord32X8 (W32# x) = Word32X8 (broadcastWord32X8# x)
+
+{-# INLINE[1] generateWord32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X8 :: (Int -> Word32) -> Word32X8
+generateWord32X8 f = packWord32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word64X2.hs
+++ b/src-256/Data/Primitive/SIMD/Word64X2.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastWord64X2
+    generateVector     = generateWord64X2
     unsafeInsertVector = unsafeInsertWord64X2
     packVector         = packWord64X2
     unpackVector       = unpackWord64X2
@@ -168,6 +169,11 @@ instance Unbox Word64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X2 :: Word64 -> Word64X2
 broadcastWord64X2 (W64# x) = Word64X2 (broadcastWord64X2# x)
+
+{-# INLINE[1] generateWord64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X2 :: (Int -> Word64) -> Word64X2
+generateWord64X2 f = packWord64X2 (f 0, f 1)
 
 {-# INLINE packWord64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word64X4.hs
+++ b/src-256/Data/Primitive/SIMD/Word64X4.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastWord64X4
+    generateVector     = generateWord64X4
     unsafeInsertVector = unsafeInsertWord64X4
     packVector         = packWord64X4
     unpackVector       = unpackWord64X4
@@ -168,6 +169,11 @@ instance Unbox Word64X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X4 :: Word64 -> Word64X4
 broadcastWord64X4 (W64# x) = Word64X4 (broadcastWord64X4# x)
+
+{-# INLINE[1] generateWord64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X4 :: (Int -> Word64) -> Word64X4
+generateWord64X4 f = packWord64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word64X8.hs
+++ b/src-256/Data/Primitive/SIMD/Word64X8.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastWord64X8
+    generateVector     = generateWord64X8
     unsafeInsertVector = unsafeInsertWord64X8
     packVector         = packWord64X8
     unpackVector       = unpackWord64X8
@@ -170,6 +171,11 @@ instance Unbox Word64X8
 broadcastWord64X8 :: Word64 -> Word64X8
 broadcastWord64X8 (W64# x) = case broadcastWord64X4# x of
     v -> Word64X8 v v
+
+{-# INLINE[1] generateWord64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X8 :: (Int -> Word64) -> Word64X8
+generateWord64X8 f = packWord64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word8X16.hs
+++ b/src-256/Data/Primitive/SIMD/Word8X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastWord8X16
+    generateVector     = generateWord8X16
     unsafeInsertVector = unsafeInsertWord8X16
     packVector         = packWord8X16
     unpackVector       = unpackWord8X16
@@ -158,6 +159,11 @@ instance Unbox Word8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord8X16 :: Word8 -> Word8X16
 broadcastWord8X16 (W8# x) = Word8X16 (broadcastWord8X16# x)
+
+{-# INLINE[1] generateWord8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X16 :: (Int -> Word8) -> Word8X16
+generateWord8X16 f = packWord8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word8X32.hs
+++ b/src-256/Data/Primitive/SIMD/Word8X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastWord8X32
+    generateVector     = generateWord8X32
     unsafeInsertVector = unsafeInsertWord8X32
     packVector         = packWord8X32
     unpackVector       = unpackWord8X32
@@ -158,6 +159,11 @@ instance Unbox Word8X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord8X32 :: Word8 -> Word8X32
 broadcastWord8X32 (W8# x) = Word8X32 (broadcastWord8X32# x)
+
+{-# INLINE[1] generateWord8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X32 :: (Int -> Word8) -> Word8X32
+generateWord8X32 f = packWord8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-256/Data/Primitive/SIMD/Word8X64.hs
+++ b/src-256/Data/Primitive/SIMD/Word8X64.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastWord8X64
+    generateVector     = generateWord8X64
     unsafeInsertVector = unsafeInsertWord8X64
     packVector         = packWord8X64
     unpackVector       = unpackWord8X64
@@ -160,6 +161,11 @@ instance Unbox Word8X64
 broadcastWord8X64 :: Word8 -> Word8X64
 broadcastWord8X64 (W8# x) = case broadcastWord8X32# x of
     v -> Word8X64 v v
+
+{-# INLINE[1] generateWord8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X64 :: (Int -> Word8) -> Word8X64
+generateWord8X64 f = packWord8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packWord8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Class.hs
+++ b/src-512/Data/Primitive/SIMD/Class.hs
@@ -35,6 +35,9 @@ class (Num v, Real (Elem v)) => SIMDVector v where
     elementSize      :: v -> Int
     -- | Broadcast a scalar to all elements of a vector.
     broadcastVector  :: Elem v -> v
+    -- | The vector that results from applying the given function to all indices in
+    --   the range @0 .. 'vectorSize' - 1@.
+    generateVector   :: (Int -> Elem v) -> v
     -- | Insert a scalar at the given position (starting from 0) in a vector. If the index is outside of the range an exception is thrown.
     insertVector     :: v -> Elem v -> Int -> v
     insertVector v e i | i < 0            = error $ "insertVector: negative argument: " ++ show i

--- a/src-512/Data/Primitive/SIMD/DoubleX16.hs
+++ b/src-512/Data/Primitive/SIMD/DoubleX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX16 where
     vectorSize  _      = 16
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX16
+    generateVector     = generateDoubleX16
     unsafeInsertVector = unsafeInsertDoubleX16
     packVector         = packDoubleX16
     unpackVector       = unpackDoubleX16
@@ -176,6 +177,11 @@ instance Unbox DoubleX16
 broadcastDoubleX16 :: Double -> DoubleX16
 broadcastDoubleX16 (D# x) = case broadcastDoubleX8# x of
     v -> DoubleX16 v v
+
+{-# INLINE[1] generateDoubleX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX16 :: (Int -> Double) -> DoubleX16
+generateDoubleX16 f = packDoubleX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packDoubleX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/DoubleX2.hs
+++ b/src-512/Data/Primitive/SIMD/DoubleX2.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX2
+    generateVector     = generateDoubleX2
     unsafeInsertVector = unsafeInsertDoubleX2
     packVector         = packDoubleX2
     unpackVector       = unpackDoubleX2
@@ -174,6 +175,11 @@ instance Unbox DoubleX2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX2 :: Double -> DoubleX2
 broadcastDoubleX2 (D# x) = DoubleX2 (broadcastDoubleX2# x)
+
+{-# INLINE[1] generateDoubleX2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX2 :: (Int -> Double) -> DoubleX2
+generateDoubleX2 f = packDoubleX2 (f 0, f 1)
 
 {-# INLINE packDoubleX2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/DoubleX4.hs
+++ b/src-512/Data/Primitive/SIMD/DoubleX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX4
+    generateVector     = generateDoubleX4
     unsafeInsertVector = unsafeInsertDoubleX4
     packVector         = packDoubleX4
     unpackVector       = unpackDoubleX4
@@ -174,6 +175,11 @@ instance Unbox DoubleX4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX4 :: Double -> DoubleX4
 broadcastDoubleX4 (D# x) = DoubleX4 (broadcastDoubleX4# x)
+
+{-# INLINE[1] generateDoubleX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX4 :: (Int -> Double) -> DoubleX4
+generateDoubleX4 f = packDoubleX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packDoubleX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/DoubleX8.hs
+++ b/src-512/Data/Primitive/SIMD/DoubleX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector DoubleX8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX8
+    generateVector     = generateDoubleX8
     unsafeInsertVector = unsafeInsertDoubleX8
     packVector         = packDoubleX8
     unpackVector       = unpackDoubleX8
@@ -174,6 +175,11 @@ instance Unbox DoubleX8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastDoubleX8 :: Double -> DoubleX8
 broadcastDoubleX8 (D# x) = DoubleX8 (broadcastDoubleX8# x)
+
+{-# INLINE[1] generateDoubleX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX8 :: (Int -> Double) -> DoubleX8
+generateDoubleX8 f = packDoubleX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packDoubleX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/FloatX16.hs
+++ b/src-512/Data/Primitive/SIMD/FloatX16.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastFloatX16
+    generateVector     = generateFloatX16
     unsafeInsertVector = unsafeInsertFloatX16
     packVector         = packFloatX16
     unpackVector       = unpackFloatX16
@@ -174,6 +175,11 @@ instance Unbox FloatX16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX16 :: Float -> FloatX16
 broadcastFloatX16 (F# x) = FloatX16 (broadcastFloatX16# x)
+
+{-# INLINE[1] generateFloatX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX16 :: (Int -> Float) -> FloatX16
+generateFloatX16 f = packFloatX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packFloatX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/FloatX4.hs
+++ b/src-512/Data/Primitive/SIMD/FloatX4.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastFloatX4
+    generateVector     = generateFloatX4
     unsafeInsertVector = unsafeInsertFloatX4
     packVector         = packFloatX4
     unpackVector       = unpackFloatX4
@@ -174,6 +175,11 @@ instance Unbox FloatX4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX4 :: Float -> FloatX4
 broadcastFloatX4 (F# x) = FloatX4 (broadcastFloatX4# x)
+
+{-# INLINE[1] generateFloatX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX4 :: (Int -> Float) -> FloatX4
+generateFloatX4 f = packFloatX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packFloatX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/FloatX8.hs
+++ b/src-512/Data/Primitive/SIMD/FloatX8.hs
@@ -113,6 +113,7 @@ instance SIMDVector FloatX8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastFloatX8
+    generateVector     = generateFloatX8
     unsafeInsertVector = unsafeInsertFloatX8
     packVector         = packFloatX8
     unpackVector       = unpackFloatX8
@@ -174,6 +175,11 @@ instance Unbox FloatX8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastFloatX8 :: Float -> FloatX8
 broadcastFloatX8 (F# x) = FloatX8 (broadcastFloatX8# x)
+
+{-# INLINE[1] generateFloatX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX8 :: (Int -> Float) -> FloatX8
+generateFloatX8 f = packFloatX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packFloatX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int16X16.hs
+++ b/src-512/Data/Primitive/SIMD/Int16X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastInt16X16
+    generateVector     = generateInt16X16
     unsafeInsertVector = unsafeInsertInt16X16
     packVector         = packInt16X16
     unpackVector       = unpackInt16X16
@@ -159,6 +160,11 @@ instance Unbox Int16X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X16 :: Int16 -> Int16X16
 broadcastInt16X16 (I16# x) = Int16X16 (broadcastInt16X16# x)
+
+{-# INLINE[1] generateInt16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X16 :: (Int -> Int16) -> Int16X16
+generateInt16X16 f = packInt16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int16X32.hs
+++ b/src-512/Data/Primitive/SIMD/Int16X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastInt16X32
+    generateVector     = generateInt16X32
     unsafeInsertVector = unsafeInsertInt16X32
     packVector         = packInt16X32
     unpackVector       = unpackInt16X32
@@ -159,6 +160,11 @@ instance Unbox Int16X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X32 :: Int16 -> Int16X32
 broadcastInt16X32 (I16# x) = Int16X32 (broadcastInt16X32# x)
+
+{-# INLINE[1] generateInt16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X32 :: (Int -> Int16) -> Int16X32
+generateInt16X32 f = packInt16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int16X8.hs
+++ b/src-512/Data/Primitive/SIMD/Int16X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastInt16X8
+    generateVector     = generateInt16X8
     unsafeInsertVector = unsafeInsertInt16X8
     packVector         = packInt16X8
     unpackVector       = unpackInt16X8
@@ -159,6 +160,11 @@ instance Unbox Int16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt16X8 :: Int16 -> Int16X8
 broadcastInt16X8 (I16# x) = Int16X8 (broadcastInt16X8# x)
+
+{-# INLINE[1] generateInt16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X8 :: (Int -> Int16) -> Int16X8
+generateInt16X8 f = packInt16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int32X16.hs
+++ b/src-512/Data/Primitive/SIMD/Int32X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastInt32X16
+    generateVector     = generateInt32X16
     unsafeInsertVector = unsafeInsertInt32X16
     packVector         = packInt32X16
     unpackVector       = unpackInt32X16
@@ -159,6 +160,11 @@ instance Unbox Int32X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X16 :: Int32 -> Int32X16
 broadcastInt32X16 (I32# x) = Int32X16 (broadcastInt32X16# x)
+
+{-# INLINE[1] generateInt32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X16 :: (Int -> Int32) -> Int32X16
+generateInt32X16 f = packInt32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int32X4.hs
+++ b/src-512/Data/Primitive/SIMD/Int32X4.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastInt32X4
+    generateVector     = generateInt32X4
     unsafeInsertVector = unsafeInsertInt32X4
     packVector         = packInt32X4
     unpackVector       = unpackInt32X4
@@ -159,6 +160,11 @@ instance Unbox Int32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X4 :: Int32 -> Int32X4
 broadcastInt32X4 (I32# x) = Int32X4 (broadcastInt32X4# x)
+
+{-# INLINE[1] generateInt32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X4 :: (Int -> Int32) -> Int32X4
+generateInt32X4 f = packInt32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int32X8.hs
+++ b/src-512/Data/Primitive/SIMD/Int32X8.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastInt32X8
+    generateVector     = generateInt32X8
     unsafeInsertVector = unsafeInsertInt32X8
     packVector         = packInt32X8
     unpackVector       = unpackInt32X8
@@ -159,6 +160,11 @@ instance Unbox Int32X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt32X8 :: Int32 -> Int32X8
 broadcastInt32X8 (I32# x) = Int32X8 (broadcastInt32X8# x)
+
+{-# INLINE[1] generateInt32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X8 :: (Int -> Int32) -> Int32X8
+generateInt32X8 f = packInt32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int64X2.hs
+++ b/src-512/Data/Primitive/SIMD/Int64X2.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastInt64X2
+    generateVector     = generateInt64X2
     unsafeInsertVector = unsafeInsertInt64X2
     packVector         = packInt64X2
     unpackVector       = unpackInt64X2
@@ -169,6 +170,11 @@ instance Unbox Int64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X2 :: Int64 -> Int64X2
 broadcastInt64X2 (I64# x) = Int64X2 (broadcastInt64X2# x)
+
+{-# INLINE[1] generateInt64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X2 :: (Int -> Int64) -> Int64X2
+generateInt64X2 f = packInt64X2 (f 0, f 1)
 
 {-# INLINE packInt64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int64X4.hs
+++ b/src-512/Data/Primitive/SIMD/Int64X4.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastInt64X4
+    generateVector     = generateInt64X4
     unsafeInsertVector = unsafeInsertInt64X4
     packVector         = packInt64X4
     unpackVector       = unpackInt64X4
@@ -169,6 +170,11 @@ instance Unbox Int64X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X4 :: Int64 -> Int64X4
 broadcastInt64X4 (I64# x) = Int64X4 (broadcastInt64X4# x)
+
+{-# INLINE[1] generateInt64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X4 :: (Int -> Int64) -> Int64X4
+generateInt64X4 f = packInt64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int64X8.hs
+++ b/src-512/Data/Primitive/SIMD/Int64X8.hs
@@ -104,6 +104,7 @@ instance SIMDVector Int64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastInt64X8
+    generateVector     = generateInt64X8
     unsafeInsertVector = unsafeInsertInt64X8
     packVector         = packInt64X8
     unpackVector       = unpackInt64X8
@@ -169,6 +170,11 @@ instance Unbox Int64X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt64X8 :: Int64 -> Int64X8
 broadcastInt64X8 (I64# x) = Int64X8 (broadcastInt64X8# x)
+
+{-# INLINE[1] generateInt64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X8 :: (Int -> Int64) -> Int64X8
+generateInt64X8 f = packInt64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int8X16.hs
+++ b/src-512/Data/Primitive/SIMD/Int8X16.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastInt8X16
+    generateVector     = generateInt8X16
     unsafeInsertVector = unsafeInsertInt8X16
     packVector         = packInt8X16
     unpackVector       = unpackInt8X16
@@ -159,6 +160,11 @@ instance Unbox Int8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt8X16 :: Int8 -> Int8X16
 broadcastInt8X16 (I8# x) = Int8X16 (broadcastInt8X16# x)
+
+{-# INLINE[1] generateInt8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X16 :: (Int -> Int8) -> Int8X16
+generateInt8X16 f = packInt8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int8X32.hs
+++ b/src-512/Data/Primitive/SIMD/Int8X32.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastInt8X32
+    generateVector     = generateInt8X32
     unsafeInsertVector = unsafeInsertInt8X32
     packVector         = packInt8X32
     unpackVector       = unpackInt8X32
@@ -159,6 +160,11 @@ instance Unbox Int8X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastInt8X32 :: Int8 -> Int8X32
 broadcastInt8X32 (I8# x) = Int8X32 (broadcastInt8X32# x)
+
+{-# INLINE[1] generateInt8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X32 :: (Int -> Int8) -> Int8X32
+generateInt8X32 f = packInt8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Int8X64.hs
+++ b/src-512/Data/Primitive/SIMD/Int8X64.hs
@@ -94,6 +94,7 @@ instance SIMDVector Int8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastInt8X64
+    generateVector     = generateInt8X64
     unsafeInsertVector = unsafeInsertInt8X64
     packVector         = packInt8X64
     unpackVector       = unpackInt8X64
@@ -161,6 +162,11 @@ instance Unbox Int8X64
 broadcastInt8X64 :: Int8 -> Int8X64
 broadcastInt8X64 (I8# x) = case broadcastInt8X32# x of
     v -> Int8X64 v v
+
+{-# INLINE[1] generateInt8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X64 :: (Int -> Int8) -> Int8X64
+generateInt8X64 f = packInt8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packInt8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word16X16.hs
+++ b/src-512/Data/Primitive/SIMD/Word16X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastWord16X16
+    generateVector     = generateWord16X16
     unsafeInsertVector = unsafeInsertWord16X16
     packVector         = packWord16X16
     unpackVector       = unpackWord16X16
@@ -158,6 +159,11 @@ instance Unbox Word16X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X16 :: Word16 -> Word16X16
 broadcastWord16X16 (W16# x) = Word16X16 (broadcastWord16X16# x)
+
+{-# INLINE[1] generateWord16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X16 :: (Int -> Word16) -> Word16X16
+generateWord16X16 f = packWord16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word16X32.hs
+++ b/src-512/Data/Primitive/SIMD/Word16X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastWord16X32
+    generateVector     = generateWord16X32
     unsafeInsertVector = unsafeInsertWord16X32
     packVector         = packWord16X32
     unpackVector       = unpackWord16X32
@@ -158,6 +159,11 @@ instance Unbox Word16X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X32 :: Word16 -> Word16X32
 broadcastWord16X32 (W16# x) = Word16X32 (broadcastWord16X32# x)
+
+{-# INLINE[1] generateWord16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X32 :: (Int -> Word16) -> Word16X32
+generateWord16X32 f = packWord16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word16X8.hs
+++ b/src-512/Data/Primitive/SIMD/Word16X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastWord16X8
+    generateVector     = generateWord16X8
     unsafeInsertVector = unsafeInsertWord16X8
     packVector         = packWord16X8
     unpackVector       = unpackWord16X8
@@ -158,6 +159,11 @@ instance Unbox Word16X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord16X8 :: Word16 -> Word16X8
 broadcastWord16X8 (W16# x) = Word16X8 (broadcastWord16X8# x)
+
+{-# INLINE[1] generateWord16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X8 :: (Int -> Word16) -> Word16X8
+generateWord16X8 f = packWord16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word32X16.hs
+++ b/src-512/Data/Primitive/SIMD/Word32X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastWord32X16
+    generateVector     = generateWord32X16
     unsafeInsertVector = unsafeInsertWord32X16
     packVector         = packWord32X16
     unpackVector       = unpackWord32X16
@@ -158,6 +159,11 @@ instance Unbox Word32X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X16 :: Word32 -> Word32X16
 broadcastWord32X16 (W32# x) = Word32X16 (broadcastWord32X16# x)
+
+{-# INLINE[1] generateWord32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X16 :: (Int -> Word32) -> Word32X16
+generateWord32X16 f = packWord32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word32X4.hs
+++ b/src-512/Data/Primitive/SIMD/Word32X4.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastWord32X4
+    generateVector     = generateWord32X4
     unsafeInsertVector = unsafeInsertWord32X4
     packVector         = packWord32X4
     unpackVector       = unpackWord32X4
@@ -158,6 +159,11 @@ instance Unbox Word32X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X4 :: Word32 -> Word32X4
 broadcastWord32X4 (W32# x) = Word32X4 (broadcastWord32X4# x)
+
+{-# INLINE[1] generateWord32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X4 :: (Int -> Word32) -> Word32X4
+generateWord32X4 f = packWord32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word32X8.hs
+++ b/src-512/Data/Primitive/SIMD/Word32X8.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastWord32X8
+    generateVector     = generateWord32X8
     unsafeInsertVector = unsafeInsertWord32X8
     packVector         = packWord32X8
     unpackVector       = unpackWord32X8
@@ -158,6 +159,11 @@ instance Unbox Word32X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord32X8 :: Word32 -> Word32X8
 broadcastWord32X8 (W32# x) = Word32X8 (broadcastWord32X8# x)
+
+{-# INLINE[1] generateWord32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X8 :: (Int -> Word32) -> Word32X8
+generateWord32X8 f = packWord32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word64X2.hs
+++ b/src-512/Data/Primitive/SIMD/Word64X2.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastWord64X2
+    generateVector     = generateWord64X2
     unsafeInsertVector = unsafeInsertWord64X2
     packVector         = packWord64X2
     unpackVector       = unpackWord64X2
@@ -168,6 +169,11 @@ instance Unbox Word64X2
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X2 :: Word64 -> Word64X2
 broadcastWord64X2 (W64# x) = Word64X2 (broadcastWord64X2# x)
+
+{-# INLINE[1] generateWord64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X2 :: (Int -> Word64) -> Word64X2
+generateWord64X2 f = packWord64X2 (f 0, f 1)
 
 {-# INLINE packWord64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word64X4.hs
+++ b/src-512/Data/Primitive/SIMD/Word64X4.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastWord64X4
+    generateVector     = generateWord64X4
     unsafeInsertVector = unsafeInsertWord64X4
     packVector         = packWord64X4
     unpackVector       = unpackWord64X4
@@ -168,6 +169,11 @@ instance Unbox Word64X4
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X4 :: Word64 -> Word64X4
 broadcastWord64X4 (W64# x) = Word64X4 (broadcastWord64X4# x)
+
+{-# INLINE[1] generateWord64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X4 :: (Int -> Word64) -> Word64X4
+generateWord64X4 f = packWord64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word64X8.hs
+++ b/src-512/Data/Primitive/SIMD/Word64X8.hs
@@ -103,6 +103,7 @@ instance SIMDVector Word64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastWord64X8
+    generateVector     = generateWord64X8
     unsafeInsertVector = unsafeInsertWord64X8
     packVector         = packWord64X8
     unpackVector       = unpackWord64X8
@@ -168,6 +169,11 @@ instance Unbox Word64X8
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord64X8 :: Word64 -> Word64X8
 broadcastWord64X8 (W64# x) = Word64X8 (broadcastWord64X8# x)
+
+{-# INLINE[1] generateWord64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X8 :: (Int -> Word64) -> Word64X8
+generateWord64X8 f = packWord64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word8X16.hs
+++ b/src-512/Data/Primitive/SIMD/Word8X16.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastWord8X16
+    generateVector     = generateWord8X16
     unsafeInsertVector = unsafeInsertWord8X16
     packVector         = packWord8X16
     unpackVector       = unpackWord8X16
@@ -158,6 +159,11 @@ instance Unbox Word8X16
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord8X16 :: Word8 -> Word8X16
 broadcastWord8X16 (W8# x) = Word8X16 (broadcastWord8X16# x)
+
+{-# INLINE[1] generateWord8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X16 :: (Int -> Word8) -> Word8X16
+generateWord8X16 f = packWord8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word8X32.hs
+++ b/src-512/Data/Primitive/SIMD/Word8X32.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastWord8X32
+    generateVector     = generateWord8X32
     unsafeInsertVector = unsafeInsertWord8X32
     packVector         = packWord8X32
     unpackVector       = unpackWord8X32
@@ -158,6 +159,11 @@ instance Unbox Word8X32
 -- | Broadcast a scalar to all elements of a vector.
 broadcastWord8X32 :: Word8 -> Word8X32
 broadcastWord8X32 (W8# x) = Word8X32 (broadcastWord8X32# x)
+
+{-# INLINE[1] generateWord8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X32 :: (Int -> Word8) -> Word8X32
+generateWord8X32 f = packWord8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-512/Data/Primitive/SIMD/Word8X64.hs
+++ b/src-512/Data/Primitive/SIMD/Word8X64.hs
@@ -93,6 +93,7 @@ instance SIMDVector Word8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastWord8X64
+    generateVector     = generateWord8X64
     unsafeInsertVector = unsafeInsertWord8X64
     packVector         = packWord8X64
     unpackVector       = unpackWord8X64
@@ -160,6 +161,11 @@ instance Unbox Word8X64
 broadcastWord8X64 :: Word8 -> Word8X64
 broadcastWord8X64 (W8# x) = case broadcastWord8X32# x of
     v -> Word8X64 v v
+
+{-# INLINE[1] generateWord8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X64 :: (Int -> Word8) -> Word8X64
+generateWord8X64 f = packWord8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packWord8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Class.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Class.hs
@@ -35,6 +35,9 @@ class (Num v, Real (Elem v)) => SIMDVector v where
     elementSize      :: v -> Int
     -- | Broadcast a scalar to all elements of a vector.
     broadcastVector  :: Elem v -> v
+    -- | The vector that results from applying the given function to all indices in
+    --   the range @0 .. 'vectorSize' - 1@.
+    generateVector   :: (Int -> Elem v) -> v
     -- | Insert a scalar at the given position (starting from 0) in a vector. If the index is outside of the range an exception is thrown.
     insertVector     :: v -> Elem v -> Int -> v
     insertVector v e i | i < 0            = error $ "insertVector: negative argument: " ++ show i

--- a/src-no-vec/Data/Primitive/SIMD/DoubleX16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/DoubleX16.hs
@@ -137,6 +137,7 @@ instance SIMDVector DoubleX16 where
     vectorSize  _      = 16
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX16
+    generateVector     = generateDoubleX16
     unsafeInsertVector = unsafeInsertDoubleX16
     packVector         = packDoubleX16
     unpackVector       = unpackDoubleX16
@@ -199,6 +200,11 @@ instance Unbox DoubleX16
 broadcastDoubleX16 :: Double -> DoubleX16
 broadcastDoubleX16 (D# x) = case broadcastDouble# x of
     v -> DoubleX16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateDoubleX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX16 :: (Int -> Double) -> DoubleX16
+generateDoubleX16 f = packDoubleX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packDoubleX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/DoubleX2.hs
+++ b/src-no-vec/Data/Primitive/SIMD/DoubleX2.hs
@@ -137,6 +137,7 @@ instance SIMDVector DoubleX2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX2
+    generateVector     = generateDoubleX2
     unsafeInsertVector = unsafeInsertDoubleX2
     packVector         = packDoubleX2
     unpackVector       = unpackDoubleX2
@@ -199,6 +200,11 @@ instance Unbox DoubleX2
 broadcastDoubleX2 :: Double -> DoubleX2
 broadcastDoubleX2 (D# x) = case broadcastDouble# x of
     v -> DoubleX2 v v
+
+{-# INLINE[1] generateDoubleX2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX2 :: (Int -> Double) -> DoubleX2
+generateDoubleX2 f = packDoubleX2 (f 0, f 1)
 
 {-# INLINE packDoubleX2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/DoubleX4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/DoubleX4.hs
@@ -137,6 +137,7 @@ instance SIMDVector DoubleX4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX4
+    generateVector     = generateDoubleX4
     unsafeInsertVector = unsafeInsertDoubleX4
     packVector         = packDoubleX4
     unpackVector       = unpackDoubleX4
@@ -199,6 +200,11 @@ instance Unbox DoubleX4
 broadcastDoubleX4 :: Double -> DoubleX4
 broadcastDoubleX4 (D# x) = case broadcastDouble# x of
     v -> DoubleX4 v v v v
+
+{-# INLINE[1] generateDoubleX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX4 :: (Int -> Double) -> DoubleX4
+generateDoubleX4 f = packDoubleX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packDoubleX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/DoubleX8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/DoubleX8.hs
@@ -137,6 +137,7 @@ instance SIMDVector DoubleX8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastDoubleX8
+    generateVector     = generateDoubleX8
     unsafeInsertVector = unsafeInsertDoubleX8
     packVector         = packDoubleX8
     unpackVector       = unpackDoubleX8
@@ -199,6 +200,11 @@ instance Unbox DoubleX8
 broadcastDoubleX8 :: Double -> DoubleX8
 broadcastDoubleX8 (D# x) = case broadcastDouble# x of
     v -> DoubleX8 v v v v v v v v
+
+{-# INLINE[1] generateDoubleX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateDoubleX8 :: (Int -> Double) -> DoubleX8
+generateDoubleX8 f = packDoubleX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packDoubleX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/FloatX16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/FloatX16.hs
@@ -125,6 +125,7 @@ instance SIMDVector FloatX16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastFloatX16
+    generateVector     = generateFloatX16
     unsafeInsertVector = unsafeInsertFloatX16
     packVector         = packFloatX16
     unpackVector       = unpackFloatX16
@@ -187,6 +188,11 @@ instance Unbox FloatX16
 broadcastFloatX16 :: Float -> FloatX16
 broadcastFloatX16 (F# x) = case broadcastFloat# x of
     v -> FloatX16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateFloatX16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX16 :: (Int -> Float) -> FloatX16
+generateFloatX16 f = packFloatX16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packFloatX16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/FloatX4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/FloatX4.hs
@@ -125,6 +125,7 @@ instance SIMDVector FloatX4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastFloatX4
+    generateVector     = generateFloatX4
     unsafeInsertVector = unsafeInsertFloatX4
     packVector         = packFloatX4
     unpackVector       = unpackFloatX4
@@ -187,6 +188,11 @@ instance Unbox FloatX4
 broadcastFloatX4 :: Float -> FloatX4
 broadcastFloatX4 (F# x) = case broadcastFloat# x of
     v -> FloatX4 v v v v
+
+{-# INLINE[1] generateFloatX4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX4 :: (Int -> Float) -> FloatX4
+generateFloatX4 f = packFloatX4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packFloatX4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/FloatX8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/FloatX8.hs
@@ -125,6 +125,7 @@ instance SIMDVector FloatX8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastFloatX8
+    generateVector     = generateFloatX8
     unsafeInsertVector = unsafeInsertFloatX8
     packVector         = packFloatX8
     unpackVector       = unpackFloatX8
@@ -187,6 +188,11 @@ instance Unbox FloatX8
 broadcastFloatX8 :: Float -> FloatX8
 broadcastFloatX8 (F# x) = case broadcastFloat# x of
     v -> FloatX8 v v v v v v v v
+
+{-# INLINE[1] generateFloatX8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateFloatX8 :: (Int -> Float) -> FloatX8
+generateFloatX8 f = packFloatX8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packFloatX8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int16X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int16X16.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastInt16X16
+    generateVector     = generateInt16X16
     unsafeInsertVector = unsafeInsertInt16X16
     packVector         = packInt16X16
     unpackVector       = unpackInt16X16
@@ -190,6 +191,11 @@ instance Unbox Int16X16
 broadcastInt16X16 :: Int16 -> Int16X16
 broadcastInt16X16 (I16# x) = case broadcastInt16# x of
     v -> Int16X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X16 :: (Int -> Int16) -> Int16X16
+generateInt16X16 f = packInt16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int16X32.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int16X32.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastInt16X32
+    generateVector     = generateInt16X32
     unsafeInsertVector = unsafeInsertInt16X32
     packVector         = packInt16X32
     unpackVector       = unpackInt16X32
@@ -190,6 +191,11 @@ instance Unbox Int16X32
 broadcastInt16X32 :: Int16 -> Int16X32
 broadcastInt16X32 (I16# x) = case broadcastInt16# x of
     v -> Int16X32 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X32 :: (Int -> Int16) -> Int16X32
+generateInt16X32 f = packInt16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int16X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int16X8.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastInt16X8
+    generateVector     = generateInt16X8
     unsafeInsertVector = unsafeInsertInt16X8
     packVector         = packInt16X8
     unpackVector       = unpackInt16X8
@@ -190,6 +191,11 @@ instance Unbox Int16X8
 broadcastInt16X8 :: Int16 -> Int16X8
 broadcastInt16X8 (I16# x) = case broadcastInt16# x of
     v -> Int16X8 v v v v v v v v
+
+{-# INLINE[1] generateInt16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt16X8 :: (Int -> Int16) -> Int16X8
+generateInt16X8 f = packInt16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int32X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int32X16.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastInt32X16
+    generateVector     = generateInt32X16
     unsafeInsertVector = unsafeInsertInt32X16
     packVector         = packInt32X16
     unpackVector       = unpackInt32X16
@@ -190,6 +191,11 @@ instance Unbox Int32X16
 broadcastInt32X16 :: Int32 -> Int32X16
 broadcastInt32X16 (I32# x) = case broadcastInt32# x of
     v -> Int32X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X16 :: (Int -> Int32) -> Int32X16
+generateInt32X16 f = packInt32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int32X4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int32X4.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastInt32X4
+    generateVector     = generateInt32X4
     unsafeInsertVector = unsafeInsertInt32X4
     packVector         = packInt32X4
     unpackVector       = unpackInt32X4
@@ -190,6 +191,11 @@ instance Unbox Int32X4
 broadcastInt32X4 :: Int32 -> Int32X4
 broadcastInt32X4 (I32# x) = case broadcastInt32# x of
     v -> Int32X4 v v v v
+
+{-# INLINE[1] generateInt32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X4 :: (Int -> Int32) -> Int32X4
+generateInt32X4 f = packInt32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int32X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int32X8.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastInt32X8
+    generateVector     = generateInt32X8
     unsafeInsertVector = unsafeInsertInt32X8
     packVector         = packInt32X8
     unpackVector       = unpackInt32X8
@@ -190,6 +191,11 @@ instance Unbox Int32X8
 broadcastInt32X8 :: Int32 -> Int32X8
 broadcastInt32X8 (I32# x) = case broadcastInt32# x of
     v -> Int32X8 v v v v v v v v
+
+{-# INLINE[1] generateInt32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt32X8 :: (Int -> Int32) -> Int32X8
+generateInt32X8 f = packInt32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int64X2.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int64X2.hs
@@ -134,6 +134,7 @@ instance SIMDVector Int64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastInt64X2
+    generateVector     = generateInt64X2
     unsafeInsertVector = unsafeInsertInt64X2
     packVector         = packInt64X2
     unpackVector       = unpackInt64X2
@@ -200,6 +201,11 @@ instance Unbox Int64X2
 broadcastInt64X2 :: Int64 -> Int64X2
 broadcastInt64X2 (I64# x) = case broadcastInt64# x of
     v -> Int64X2 v v
+
+{-# INLINE[1] generateInt64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X2 :: (Int -> Int64) -> Int64X2
+generateInt64X2 f = packInt64X2 (f 0, f 1)
 
 {-# INLINE packInt64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int64X4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int64X4.hs
@@ -134,6 +134,7 @@ instance SIMDVector Int64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastInt64X4
+    generateVector     = generateInt64X4
     unsafeInsertVector = unsafeInsertInt64X4
     packVector         = packInt64X4
     unpackVector       = unpackInt64X4
@@ -200,6 +201,11 @@ instance Unbox Int64X4
 broadcastInt64X4 :: Int64 -> Int64X4
 broadcastInt64X4 (I64# x) = case broadcastInt64# x of
     v -> Int64X4 v v v v
+
+{-# INLINE[1] generateInt64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X4 :: (Int -> Int64) -> Int64X4
+generateInt64X4 f = packInt64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packInt64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int64X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int64X8.hs
@@ -134,6 +134,7 @@ instance SIMDVector Int64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastInt64X8
+    generateVector     = generateInt64X8
     unsafeInsertVector = unsafeInsertInt64X8
     packVector         = packInt64X8
     unpackVector       = unpackInt64X8
@@ -200,6 +201,11 @@ instance Unbox Int64X8
 broadcastInt64X8 :: Int64 -> Int64X8
 broadcastInt64X8 (I64# x) = case broadcastInt64# x of
     v -> Int64X8 v v v v v v v v
+
+{-# INLINE[1] generateInt64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt64X8 :: (Int -> Int64) -> Int64X8
+generateInt64X8 f = packInt64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packInt64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int8X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int8X16.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastInt8X16
+    generateVector     = generateInt8X16
     unsafeInsertVector = unsafeInsertInt8X16
     packVector         = packInt8X16
     unpackVector       = unpackInt8X16
@@ -190,6 +191,11 @@ instance Unbox Int8X16
 broadcastInt8X16 :: Int8 -> Int8X16
 broadcastInt8X16 (I8# x) = case broadcastInt8# x of
     v -> Int8X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X16 :: (Int -> Int8) -> Int8X16
+generateInt8X16 f = packInt8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packInt8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int8X32.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int8X32.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastInt8X32
+    generateVector     = generateInt8X32
     unsafeInsertVector = unsafeInsertInt8X32
     packVector         = packInt8X32
     unpackVector       = unpackInt8X32
@@ -190,6 +191,11 @@ instance Unbox Int8X32
 broadcastInt8X32 :: Int8 -> Int8X32
 broadcastInt8X32 (I8# x) = case broadcastInt8# x of
     v -> Int8X32 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X32 :: (Int -> Int8) -> Int8X32
+generateInt8X32 f = packInt8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packInt8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Int8X64.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Int8X64.hs
@@ -124,6 +124,7 @@ instance SIMDVector Int8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastInt8X64
+    generateVector     = generateInt8X64
     unsafeInsertVector = unsafeInsertInt8X64
     packVector         = packInt8X64
     unpackVector       = unpackInt8X64
@@ -190,6 +191,11 @@ instance Unbox Int8X64
 broadcastInt8X64 :: Int8 -> Int8X64
 broadcastInt8X64 (I8# x) = case broadcastInt8# x of
     v -> Int8X64 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateInt8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateInt8X64 :: (Int -> Int8) -> Int8X64
+generateInt8X64 f = packInt8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packInt8X64 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word16X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word16X16.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word16X16 where
     vectorSize  _      = 16
     elementSize _      = 2
     broadcastVector    = broadcastWord16X16
+    generateVector     = generateWord16X16
     unsafeInsertVector = unsafeInsertWord16X16
     packVector         = packWord16X16
     unpackVector       = unpackWord16X16
@@ -186,6 +187,11 @@ instance Unbox Word16X16
 broadcastWord16X16 :: Word16 -> Word16X16
 broadcastWord16X16 (W16# x) = case broadcastWord16# x of
     v -> Word16X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord16X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X16 :: (Int -> Word16) -> Word16X16
+generateWord16X16 f = packWord16X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord16X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word16X32.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word16X32.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word16X32 where
     vectorSize  _      = 32
     elementSize _      = 2
     broadcastVector    = broadcastWord16X32
+    generateVector     = generateWord16X32
     unsafeInsertVector = unsafeInsertWord16X32
     packVector         = packWord16X32
     unpackVector       = unpackWord16X32
@@ -186,6 +187,11 @@ instance Unbox Word16X32
 broadcastWord16X32 :: Word16 -> Word16X32
 broadcastWord16X32 (W16# x) = case broadcastWord16# x of
     v -> Word16X32 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord16X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X32 :: (Int -> Word16) -> Word16X32
+generateWord16X32 f = packWord16X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord16X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word16X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word16X8.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word16X8 where
     vectorSize  _      = 8
     elementSize _      = 2
     broadcastVector    = broadcastWord16X8
+    generateVector     = generateWord16X8
     unsafeInsertVector = unsafeInsertWord16X8
     packVector         = packWord16X8
     unpackVector       = unpackWord16X8
@@ -186,6 +187,11 @@ instance Unbox Word16X8
 broadcastWord16X8 :: Word16 -> Word16X8
 broadcastWord16X8 (W16# x) = case broadcastWord16# x of
     v -> Word16X8 v v v v v v v v
+
+{-# INLINE[1] generateWord16X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord16X8 :: (Int -> Word16) -> Word16X8
+generateWord16X8 f = packWord16X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord16X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word32X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word32X16.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word32X16 where
     vectorSize  _      = 16
     elementSize _      = 4
     broadcastVector    = broadcastWord32X16
+    generateVector     = generateWord32X16
     unsafeInsertVector = unsafeInsertWord32X16
     packVector         = packWord32X16
     unpackVector       = unpackWord32X16
@@ -186,6 +187,11 @@ instance Unbox Word32X16
 broadcastWord32X16 :: Word32 -> Word32X16
 broadcastWord32X16 (W32# x) = case broadcastWord32# x of
     v -> Word32X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord32X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X16 :: (Int -> Word32) -> Word32X16
+generateWord32X16 f = packWord32X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord32X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word32X4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word32X4.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word32X4 where
     vectorSize  _      = 4
     elementSize _      = 4
     broadcastVector    = broadcastWord32X4
+    generateVector     = generateWord32X4
     unsafeInsertVector = unsafeInsertWord32X4
     packVector         = packWord32X4
     unpackVector       = unpackWord32X4
@@ -186,6 +187,11 @@ instance Unbox Word32X4
 broadcastWord32X4 :: Word32 -> Word32X4
 broadcastWord32X4 (W32# x) = case broadcastWord32# x of
     v -> Word32X4 v v v v
+
+{-# INLINE[1] generateWord32X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X4 :: (Int -> Word32) -> Word32X4
+generateWord32X4 f = packWord32X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord32X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word32X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word32X8.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word32X8 where
     vectorSize  _      = 8
     elementSize _      = 4
     broadcastVector    = broadcastWord32X8
+    generateVector     = generateWord32X8
     unsafeInsertVector = unsafeInsertWord32X8
     packVector         = packWord32X8
     unpackVector       = unpackWord32X8
@@ -186,6 +187,11 @@ instance Unbox Word32X8
 broadcastWord32X8 :: Word32 -> Word32X8
 broadcastWord32X8 (W32# x) = case broadcastWord32# x of
     v -> Word32X8 v v v v v v v v
+
+{-# INLINE[1] generateWord32X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord32X8 :: (Int -> Word32) -> Word32X8
+generateWord32X8 f = packWord32X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord32X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word64X2.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word64X2.hs
@@ -130,6 +130,7 @@ instance SIMDVector Word64X2 where
     vectorSize  _      = 2
     elementSize _      = 8
     broadcastVector    = broadcastWord64X2
+    generateVector     = generateWord64X2
     unsafeInsertVector = unsafeInsertWord64X2
     packVector         = packWord64X2
     unpackVector       = unpackWord64X2
@@ -196,6 +197,11 @@ instance Unbox Word64X2
 broadcastWord64X2 :: Word64 -> Word64X2
 broadcastWord64X2 (W64# x) = case broadcastWord64# x of
     v -> Word64X2 v v
+
+{-# INLINE[1] generateWord64X2 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X2 :: (Int -> Word64) -> Word64X2
+generateWord64X2 f = packWord64X2 (f 0, f 1)
 
 {-# INLINE packWord64X2 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word64X4.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word64X4.hs
@@ -130,6 +130,7 @@ instance SIMDVector Word64X4 where
     vectorSize  _      = 4
     elementSize _      = 8
     broadcastVector    = broadcastWord64X4
+    generateVector     = generateWord64X4
     unsafeInsertVector = unsafeInsertWord64X4
     packVector         = packWord64X4
     unpackVector       = unpackWord64X4
@@ -196,6 +197,11 @@ instance Unbox Word64X4
 broadcastWord64X4 :: Word64 -> Word64X4
 broadcastWord64X4 (W64# x) = case broadcastWord64# x of
     v -> Word64X4 v v v v
+
+{-# INLINE[1] generateWord64X4 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X4 :: (Int -> Word64) -> Word64X4
+generateWord64X4 f = packWord64X4 (f 0, f 1, f 2, f 3)
 
 {-# INLINE packWord64X4 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word64X8.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word64X8.hs
@@ -130,6 +130,7 @@ instance SIMDVector Word64X8 where
     vectorSize  _      = 8
     elementSize _      = 8
     broadcastVector    = broadcastWord64X8
+    generateVector     = generateWord64X8
     unsafeInsertVector = unsafeInsertWord64X8
     packVector         = packWord64X8
     unpackVector       = unpackWord64X8
@@ -196,6 +197,11 @@ instance Unbox Word64X8
 broadcastWord64X8 :: Word64 -> Word64X8
 broadcastWord64X8 (W64# x) = case broadcastWord64# x of
     v -> Word64X8 v v v v v v v v
+
+{-# INLINE[1] generateWord64X8 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord64X8 :: (Int -> Word64) -> Word64X8
+generateWord64X8 f = packWord64X8 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7)
 
 {-# INLINE packWord64X8 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word8X16.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word8X16.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word8X16 where
     vectorSize  _      = 16
     elementSize _      = 1
     broadcastVector    = broadcastWord8X16
+    generateVector     = generateWord8X16
     unsafeInsertVector = unsafeInsertWord8X16
     packVector         = packWord8X16
     unpackVector       = unpackWord8X16
@@ -186,6 +187,11 @@ instance Unbox Word8X16
 broadcastWord8X16 :: Word8 -> Word8X16
 broadcastWord8X16 (W8# x) = case broadcastWord8# x of
     v -> Word8X16 v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord8X16 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X16 :: (Int -> Word8) -> Word8X16
+generateWord8X16 f = packWord8X16 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15)
 
 {-# INLINE packWord8X16 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word8X32.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word8X32.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word8X32 where
     vectorSize  _      = 32
     elementSize _      = 1
     broadcastVector    = broadcastWord8X32
+    generateVector     = generateWord8X32
     unsafeInsertVector = unsafeInsertWord8X32
     packVector         = packWord8X32
     unpackVector       = unpackWord8X32
@@ -186,6 +187,11 @@ instance Unbox Word8X32
 broadcastWord8X32 :: Word8 -> Word8X32
 broadcastWord8X32 (W8# x) = case broadcastWord8# x of
     v -> Word8X32 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord8X32 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X32 :: (Int -> Word8) -> Word8X32
+generateWord8X32 f = packWord8X32 (f 0, f 1, f 2, f 3, f 4, f 5, f 6, f 7, f 8, f 9, f 10, f 11, f 12, f 13, f 14, f 15, f 16, f 17, f 18, f 19, f 20, f 21, f 22, f 23, f 24, f 25, f 26, f 27, f 28, f 29, f 30, f 31)
 
 {-# INLINE packWord8X32 #-}
 -- | Pack the elements of a tuple into a vector.

--- a/src-no-vec/Data/Primitive/SIMD/Word8X64.hs
+++ b/src-no-vec/Data/Primitive/SIMD/Word8X64.hs
@@ -120,6 +120,7 @@ instance SIMDVector Word8X64 where
     vectorSize  _      = 64
     elementSize _      = 1
     broadcastVector    = broadcastWord8X64
+    generateVector     = generateWord8X64
     unsafeInsertVector = unsafeInsertWord8X64
     packVector         = packWord8X64
     unpackVector       = unpackWord8X64
@@ -186,6 +187,11 @@ instance Unbox Word8X64
 broadcastWord8X64 :: Word8 -> Word8X64
 broadcastWord8X64 (W8# x) = case broadcastWord8# x of
     v -> Word8X64 v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v v
+
+{-# INLINE[1] generateWord8X64 #-}
+-- | Apply a function to each element of a vector (unpacks and repacks the vector)
+generateWord8X64 :: (Int -> Word8) -> Word8X64
+generateWord8X64 f = packWord8X64 (Tuple64 (f 0) (f 1) (f 2) (f 3) (f 4) (f 5) (f 6) (f 7) (f 8) (f 9) (f 10) (f 11) (f 12) (f 13) (f 14) (f 15) (f 16) (f 17) (f 18) (f 19) (f 20) (f 21) (f 22) (f 23) (f 24) (f 25) (f 26) (f 27) (f 28) (f 29) (f 30) (f 31) (f 32) (f 33) (f 34) (f 35) (f 36) (f 37) (f 38) (f 39) (f 40) (f 41) (f 42) (f 43) (f 44) (f 45) (f 46) (f 47) (f 48) (f 49) (f 50) (f 51) (f 52) (f 53) (f 54) (f 55) (f 56) (f 57) (f 58) (f 59) (f 60) (f 61) (f 62) (f 63))
 
 {-# INLINE packWord8X64 #-}
 -- | Pack the elements of a tuple into a vector.


### PR DESCRIPTION
It is awkward to have to explicitly pack tuples of the right size. Usually the entries will come from some kind of otherwise structure data anyway and the tuples will look quite boring, of the form `pack (f 0, f 1, f 2, f3)`.

This PR adds a method that adresses this way of constructing vectors, namely
```haskell
generateVector :: (Int -> Elem v) -> v
```
This is analogous to [`Data.Vector.generate`](http://hackage.haskell.org/package/vector-0.12.0.1/docs/Data-Vector.html#v:generate), except the desired length is (like for `broadcastVector`) already determined by the type.
```haskell
generate :: Int -> (Int -> a) -> Vector a
```